### PR TITLE
Add modal select folder

### DIFF
--- a/components/file-browser/file-browser.js
+++ b/components/file-browser/file-browser.js
@@ -86,7 +86,7 @@
                         on-delete="onDeleteFileOrFolder()">
                     </delete> 
                 `)($scope));
-            }
+            };
             $scope.uploadFile = (file) => {
                 if (typeof file !== 'undefined') {
                     let checkSameFileName = typeof $scope.dataBrowseDirectory.fileDetails.find(fileDetail => fileDetail.type === 'FILE' && fileDetail.fileName === file.name) === 'undefined';

--- a/components/modal-select-file-or-directory/modal-select-file-or-directory.html
+++ b/components/modal-select-file-or-directory/modal-select-file-or-directory.html
@@ -21,21 +21,19 @@
                                 <th>Last Modified</th>
                                 <th>Owner</th>
                                 <th>Group</th>
-                                <th>
-                                    <div class="d-flex justify-content-between">
-                                        Permission
-                                        <span ng-show="$ctrl.canAddFolder">
-                                            <i class="material-icons" ng-click="addFolder()"
-                                                ng-hide="nowRootPath">create_new_folder</i>
-                                        </span>
-                                    </div>
+                                <th>Permission</th>
+                                <th class="text-right">
+                                    <span ng-show="$ctrl.canAddFolder">
+                                        <i class="material-icons" ng-click="addFolder()"
+                                            ng-hide="nowRootPath">create_new_folder</i>
+                                    </span>
                                 </th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr ng-hide="nowRootPath" ng-click="upDir()">
                                 <td><i class="fas fa-arrow-up"></i></td>
-                                <td colspan="6">
+                                <td colspan="7">
                                     <strong>..{{dataBrowseDirectory.currentDir}}</strong>
                                 </td>
                             </tr>
@@ -43,7 +41,7 @@
                                 <td>
                                     <i class="far fa-folder"></i>
                                 </td>
-                                <td colspan="6">
+                                <td colspan="7">
                                     <form name="formNewFolder" class="input-group input-group-sm"
                                         ng-submit="saveFolder(folderName)">
                                         <input type="text" name="folderName" ng-attr-id="{{'first-input-'+id}}"
@@ -59,17 +57,24 @@
                             </tr>
                             <tr ng-repeat="fileDetail in dataBrowseDirectory.fileDetails track by $index"
                                 ng-class="{'bg-primary': fileDetail.selected}"
-                                ng-style="{color: fileDetail.selected? 'white': ''}" ng-click="onClick(fileDetail)">
-                                <td>
+                                ng-style="{color: fileDetail.selected? 'white': ''}">
+                                <td ng-click="onClick(fileDetail)">
                                     <i class="far fa-file" ng-if="fileDetail.type === 'FILE'"></i>
                                     <i class="far fa-folder" ng-if="fileDetail.type === 'DIRECTORY'"></i>
                                 </td>
-                                <td>{{fileDetail.fileName}}</td>
-                                <td><span ng-if="fileDetail.byteSize !== 0">{{fileDetail.byteSize}}</span></td>
-                                <td>{{fileDetail.lastModified}}</td>
-                                <td>{{fileDetail.owner}}</td>
-                                <td>{{fileDetail.group}}</td>
-                                <td>{{fileDetail.permission}}</td>
+                                <td ng-click="onClick(fileDetail)">{{fileDetail.fileName}}</td>
+                                <td ng-click="onClick(fileDetail)"><span
+                                        ng-if="fileDetail.byteSize !== 0">{{fileDetail.byteSize}}</span></td>
+                                <td ng-click="onClick(fileDetail)">{{fileDetail.lastModified}}</td>
+                                <td ng-click="onClick(fileDetail)">{{fileDetail.owner}}</td>
+                                <td ng-click="onClick(fileDetail)">{{fileDetail.group}}</td>
+                                <td ng-click="onClick(fileDetail)">{{fileDetail.permission}}</td>
+                                <td class="text-right">
+                                    <span ng-show="$ctrl.canAddFolder">
+                                        <i class="far fa-trash-alt" ng-hide="nowRootPath"
+                                            ng-click="deleteFolder(fileDetail)"></i>
+                                    </span>
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/components/modal-select-file-or-directory/modal-select-file-or-directory.html
+++ b/components/modal-select-file-or-directory/modal-select-file-or-directory.html
@@ -21,7 +21,15 @@
                                 <th>Last Modified</th>
                                 <th>Owner</th>
                                 <th>Group</th>
-                                <th>Permission</th>
+                                <th>
+                                    <div class="d-flex justify-content-between">
+                                        Permission
+                                        <span ng-show="$ctrl.canAddFolder">
+                                            <i class="material-icons" ng-click="addFolder()"
+                                                ng-hide="nowRootPath">create_new_folder</i>
+                                        </span>
+                                    </div>
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
@@ -29,6 +37,24 @@
                                 <td><i class="fas fa-arrow-up"></i></td>
                                 <td colspan="6">
                                     <strong>..{{dataBrowseDirectory.currentDir}}</strong>
+                                </td>
+                            </tr>
+                            <tr ng-show="formAddFolderShow">
+                                <td>
+                                    <i class="far fa-folder"></i>
+                                </td>
+                                <td colspan="6">
+                                    <form name="formNewFolder" class="input-group input-group-sm"
+                                        ng-submit="saveFolder(folderName)">
+                                        <input type="text" name="folderName" ng-attr-id="{{'first-input-'+id}}"
+                                            class="form-control" placeholder="Folder Name" ng-model="folderName"
+                                            required>
+                                        <div class="input-group-append">
+                                            <button class="btn btn-primary" type="submit">Save</button>
+                                            <button class="btn btn-danger" type="reset"
+                                                ng-click="formAddFolderShow=false">Cancel</button>
+                                        </div>
+                                    </form>
                                 </td>
                             </tr>
                             <tr ng-repeat="fileDetail in dataBrowseDirectory.fileDetails track by $index"

--- a/components/modal-select-file-or-directory/modal-select-file-or-directory.js
+++ b/components/modal-select-file-or-directory/modal-select-file-or-directory.js
@@ -55,6 +55,13 @@
                     if ($ctrl.getDirectory === true) {
                         model.fileDetails = model.fileDetails.filter(({ type }) => type === 'DIRECTORY');
                     }
+                },
+                refresh = (callback) => {
+                    TenantUserService.browseDirectory($scope.dataBrowseDirectory.currentDir)
+                        .then(resBrowseDirectory => {
+                            $scope.dataBrowseDirectory = resBrowseDirectory;
+                            callback();
+                        });
                 };
             $timeout(() => {
                 modalElement = angular.element(`#modal-${$scope.id}`);
@@ -113,20 +120,37 @@
                         .then(() => {
                             $scope.folderName = '';
                             $scope.formAddFolderShow = false;
-                            TenantUserService.browseDirectory($scope.dataBrowseDirectory.currentDir)
-                                .then(resBrowseDirectory => {
-                                    $scope.dataBrowseDirectory = resBrowseDirectory;
-                                    filterDirectory($scope.dataBrowseDirectory);
-                                    $element.append($compile(`
-                                        <alert type="success" title="Create folder '${folderName}' has been success."></alert>
-                                    `)($scope));
-                                });
+                            refresh(() => {
+                                filterDirectory($scope.dataBrowseDirectory);
+                                $element.append($compile(`
+                                    <alert type="success" title="Create folder '${folderName}' has been success."></alert>
+                                `)($scope));
+                            });
                         });
                 } else {
                     $element.append($compile(`
                         <alert type="danger" title="This destination already contains a folder named '${folderName}'!" body="Please change a folder name."></alert>
                     `)($scope));
                 }
+            };
+            $scope.deleteFolder = (fileDetail) => {
+                $scope.onDeleteFolder = () => {
+                    TenantUserService.removeFile(fileDetail.filePath)
+                        .then(() => {
+                            refresh(() => {
+                                filterDirectory($scope.dataBrowseDirectory);
+                                $element.append($compile(`
+                                    <alert type="success" title="Delete success."></alert>
+                                `)($scope));
+                            });
+                        });
+                };
+                $element.append($compile(`
+                    <delete title="Delete This Folder?"
+                        body="Confirm if you are going to delete <strong>${fileDetail.fileName}</strong>."
+                        on-delete="onDeleteFolder()">
+                    </delete> 
+                `)($scope));
             };
         };
     }

--- a/index.html
+++ b/index.html
@@ -24,7 +24,8 @@
 
 <body ng-app="Magnotia">
     <!-- route: app -->
-    <div ui-view></div>
+    <!-- <div ui-view></div> -->
+    <modal-select-file-or-directory get-directory="true" can-add-folder="true"></modal-select-file-or-directory>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
 
 <body ng-app="Magnotia">
     <!-- route: app -->
-    <!-- <div ui-view></div> -->
-    <modal-select-file-or-directory get-directory="true" can-add-folder="true"></modal-select-file-or-directory>
+    <div ui-view></div>
+    <!-- <modal-select-file-or-directory get-directory="true" can-add-folder="true"></modal-select-file-or-directory> -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"></script>

--- a/views/tenant-user/application-suite/form-new-instance/form-new-instance.html
+++ b/views/tenant-user/application-suite/form-new-instance/form-new-instance.html
@@ -45,22 +45,35 @@
                     ng-model="instance.description" required>
                 <div ng-repeat="property in properties track by $index">
                     <label ng-attr-for="{{property.propertyName}}">{{property.propertyName}}</label>
-                    <input ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
-                        class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
-                        ng-if="!property.propertyFormat || property.propertyFormat == 'text' || property.propertyFormat == 'password'"
-                        type="{{property.propertyFormat}}" placeholder="{{property.propertyName}}"
-                        ng-model="property.propertyValue" required>
-                    <textarea ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
-                        class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
-                        placeholder="{{property.propertyName}}"
-                        ng-if="!property.propertyFormat || property.propertyFormat == 'area'"
-                        ng-model="property.propertyValue" required></textarea>
-                    <select ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
-                        class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
-                        ng-if="property.propertyFormat && property.propertyFormat == 'select'"
-                        ng-model="property.propertyValue" required>
-                        <option ng-repeat="key in property.selection" ng-value="key">{{key}}</option>
-                    </select>
+                    <span ng-if="property.propertyName !== 'Output Directory'">
+                        <input ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                            class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
+                            ng-if="!property.propertyFormat || property.propertyFormat == 'text' || property.propertyFormat == 'password'"
+                            type="{{property.propertyFormat}}" placeholder="{{property.propertyName}}"
+                            ng-model="property.propertyValue" required>
+                        <textarea ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                            class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
+                            placeholder="{{property.propertyName}}"
+                            ng-if="!property.propertyFormat || property.propertyFormat == 'area'"
+                            ng-model="property.propertyValue" required></textarea>
+                        <select ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                            class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
+                            ng-if="property.propertyFormat && property.propertyFormat == 'select'"
+                            ng-model="property.propertyValue" required>
+                            <option ng-repeat="key in property.selection" ng-value="key">{{key}}</option>
+                        </select>
+                    </span>
+                    <div class="input-group" ng-if="property.propertyName === 'Output Directory'">
+                        <input ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                            class="form-control" ng-class="{'is-valid':formNewInstance[property.propertyName].$valid}"
+                            ng-if="!property.propertyFormat || property.propertyFormat == 'text' || property.propertyFormat == 'password'"
+                            type="{{property.propertyFormat}}" placeholder="{{property.propertyName}}"
+                            ng-model="property.propertyValue" required>
+                        <div class="input-group-append">
+                            <button class="btn btn-primary" type="button" ng-click="selectFolder($index)">Select
+                                Folder</button>
+                        </div>
+                    </div>
                 </div>
                 <div style="margin-top: 30px;">
                     <button class="btn btn-primary" type="submit"

--- a/views/tenant-user/application-suite/form-new-instance/form-new-instance.js
+++ b/views/tenant-user/application-suite/form-new-instance/form-new-instance.js
@@ -12,9 +12,9 @@
             controller: tenantUserApplicationSuiteFormNewInstanceController,
         });
 
-    tenantUserApplicationSuiteFormNewInstanceController.$inject = ['$scope', '$stateParams', '$state', '$compile', '$element', 'applicationPoolService'];
+    tenantUserApplicationSuiteFormNewInstanceController.$inject = ['$scope', '$stateParams', '$state', '$compile', '$element', '$timeout', 'applicationPoolService'];
 
-    function tenantUserApplicationSuiteFormNewInstanceController($scope, $stateParams, $state, $compile, $element, applicationPoolService) {
+    function tenantUserApplicationSuiteFormNewInstanceController($scope, $stateParams, $state, $compile, $element, $timeout, applicationPoolService) {
         var $ctrl = this;
 
         $ctrl.$onInit = function () {
@@ -68,11 +68,6 @@
                         })).filter(_ => typeof _ !== 'undefined');
                     });
             };
-
-            /**
-             * @todo
-             * check setiap parameter tidak boleh kosong. jika kosong alert error.
-             */
             $scope.save = (applicationNow, instance, properties) => {
                 applicationPoolService.saveApplicationInstance(Object.assign({
                     applicationId: applicationNow.id,
@@ -85,6 +80,12 @@
                             <alert type="success" title="Add new application instance success." on-close="onClose()"></alert>
                         `)($scope));
                     });
+            };
+            $scope.selectFolder = (indexOfProperty) => {
+                $scope.onOpen = (path) => $scope.properties[indexOfProperty].propertyValue = path;
+                $element.append($compile(`
+                    <modal-select-file-or-directory get-directory="true" can-add-folder="true" on-open="onOpen(path)"></modal-select-file-or-directory>
+                `)($scope));
             };
         };
     }

--- a/views/tenant-user/application-suite/form-update-application-instance/form-update-application-instance.html
+++ b/views/tenant-user/application-suite/form-update-application-instance/form-update-application-instance.html
@@ -19,25 +19,39 @@
                 placeholder="Description" ng-model="instance.description" required>
             <div ng-repeat="property in properties track by $index">
                 <label ng-attr-for="{{property.propertyName}}">{{property.propertyName}}</label>
-                <input ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
-                    class="form-control"
-                    ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
-                    ng-if="!property.propertyFormat || property.propertyFormat == 'text' || property.propertyFormat == 'password'"
-                    type="{{property.propertyFormat}}" placeholder="{{property.propertyName}}"
-                    ng-model="property.propertyValue" required>
-                <textarea ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
-                    class="form-control"
-                    ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
-                    placeholder="{{property.propertyName}}"
-                    ng-if="!property.propertyFormat || property.propertyFormat == 'area'"
-                    ng-model="property.propertyValue" required></textarea>
-                <select ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
-                    class="form-control"
-                    ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
-                    ng-if="property.propertyFormat && property.propertyFormat == 'select'"
-                    ng-model="property.propertyValue" required>
-                    <option ng-repeat="key in property.selection" ng-value="key">{{key}}</option>
-                </select>
+                <span ng-if="property.propertyName !== 'Output Directory'">
+                    <input ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                        class="form-control"
+                        ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
+                        ng-if="!property.propertyFormat || property.propertyFormat == 'text' || property.propertyFormat == 'password'"
+                        type="{{property.propertyFormat}}" placeholder="{{property.propertyName}}"
+                        ng-model="property.propertyValue" required>
+                    <textarea ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                        class="form-control"
+                        ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
+                        placeholder="{{property.propertyName}}"
+                        ng-if="!property.propertyFormat || property.propertyFormat == 'area'"
+                        ng-model="property.propertyValue" required></textarea>
+                    <select ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                        class="form-control"
+                        ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
+                        ng-if="property.propertyFormat && property.propertyFormat == 'select'"
+                        ng-model="property.propertyValue" required>
+                        <option ng-repeat="key in property.selection" ng-value="key">{{key}}</option>
+                    </select>
+                </span>
+                <div class="input-group" ng-if="property.propertyName === 'Output Directory'">
+                    <input ng-attr-id="{{property.propertyName}}" ng-attr-name="{{property.propertyName}}"
+                        class="form-control"
+                        ng-class="{'is-valid':formUpdateApplicationInstance[property.propertyName].$valid}"
+                        ng-if="!property.propertyFormat || property.propertyFormat == 'text' || property.propertyFormat == 'password'"
+                        type="{{property.propertyFormat}}" placeholder="{{property.propertyName}}"
+                        ng-model="property.propertyValue" required>
+                    <div class="input-group-append">
+                        <button class="btn btn-primary" type="button" ng-click="selectFolder($index)">Select
+                            Folder</button>
+                    </div>
+                </div>
             </div>
             <div style="margin-top: 30px;">
                 <button class="btn btn-primary" type="submit"

--- a/views/tenant-user/application-suite/form-update-application-instance/form-update-application-instance.js
+++ b/views/tenant-user/application-suite/form-update-application-instance/form-update-application-instance.js
@@ -79,6 +79,12 @@
                         $element.append($compile(`<alert type="success" title="Update success." on-close="onClose()"></alert>`)($scope));
                     });
             };
+            $scope.selectFolder = (indexOfProperty) => {
+                $scope.onOpen = (path) => $scope.properties[indexOfProperty].propertyValue = path;
+                $element.append($compile(`
+                    <modal-select-file-or-directory get-directory="true" can-add-folder="true" on-open="onOpen(path)"></modal-select-file-or-directory>
+                `)($scope));
+            };
         };
     }
 })();


### PR DESCRIPTION
Add modal select folder on output file directory when add or reconfigure application instance.
Work done:
- [x] Update component modal-select-file-or-directory, consists of:
- add status canAddFolder
- add form input new folder
- [x] Update view form-update-application-instance, consists of:
- add input group when propertyName equal 'Output Directory'
- add modal-select-file-or-directory with status can-add-folder
- [x] Update view form-new-instance, all change is same with view form-update-application-instance